### PR TITLE
fix: adding second address gives error

### DIFF
--- a/src/db/models.js
+++ b/src/db/models.js
@@ -118,7 +118,7 @@ const Address = db.define('address', definitions.demographics.address, {
         {
             name: 'unique_primary_address_index',
             unique: true,
-            fields: ['demographicId'],
+            fields: ['id'],
             where: {primary: true}
         }
     ]

--- a/src/routers/api/address.js
+++ b/src/routers/api/address.js
@@ -27,7 +27,7 @@ router.post('/', cel.ensureLoggedIn('/login'), function (req, res) {
             countryId: req.body.countryId,
             demographicId: demographics.id,
             // if no addresses, then first one added is primary
-            primary: !demographics.address || demographics.addresses.length === 0
+            primary: !demographics.addresses || demographics.addresses.length === 0
 
         }))
             .then((address) => res.redirect('/address/' + address.id))


### PR DESCRIPTION
fixes #121.

**Changes:**

- Set unique constraint for "id" instead of "demographicId". (because one user can have more than one address, So "demographicId" in addresses table can be repeated.)
- Fix bug at initialising "primary" field of address.