### PR TITLE
fix: navigation bar is overlapping on /clients/:id page

### DIFF
--- a/views/client/id.hbs
+++ b/views/client/id.hbs
@@ -1,6 +1,6 @@
 {{!< main}}
 
-<div class="container">
+<div class="container p-4 mt-4">
     <div class="h3 thin-font text-center">Client Details</div>
     <div class="col-md-12 col-lg-10 offset-lg-1">
         <a href="/clients/{{client.id}}/edit"><div class="btn btn-sm btn-info">Edit</div></a>


### PR DESCRIPTION
fixes #140.

**After changes:**
![cb-after](https://user-images.githubusercontent.com/27485533/40198536-5db8c7fe-5a34-11e8-9073-a86dd22ae1bc.png)
