### PR TITLE
fix: error message is showing twice on /users/me page

### DIFF
--- a/views/user/me.hbs
+++ b/views/user/me.hbs
@@ -62,9 +62,6 @@
                 <p class="custom-profile-padding col-6"> {{user.role}} </p>
             </div>
         {{/if}}
-        {{#if messages.error}}
-            <span class="alert alert-danger">{{messages.error}}</span>
-        {{/if}}
 
         {{#if user.userfacebook}}
             <div id="profile-row-fb" class="row">


### PR DESCRIPTION
fixes #138.

**After change:**
![cb-after-errmsg](https://user-images.githubusercontent.com/27485533/40199245-82e0b288-5a36-11e8-9692-0a58398f86e9.png)
