### PR TITLE
fixed Overflowing text in Oauth links

### DIFF
--- a/views/login.hbs
+++ b/views/login.hbs
@@ -20,7 +20,7 @@
 
     <div class="row">
         <div class="col"></div>
-        <div class="col-6">
+        <div class="col-12 col-sm-6">
             <a class="btn custom-social-btn btn-block btn-facebook" href="/login/facebook">
               <i class="fa fa-facebook"></i> Login
               <span class="hidden-xs-down">with Facebook</span>


### PR DESCRIPTION
#127 
previously - 
![screenshot from 2018-05-18 23-43-22](https://user-images.githubusercontent.com/5001704/40250961-8cbe2924-5af5-11e8-874a-5ea5d08eaf9f.png)
Now - 
![screenshot from 2018-05-18 23-43-31](https://user-images.githubusercontent.com/5001704/40250989-9bc853fe-5af5-11e8-8325-7752945890b1.png)

