### PR TITLE
Fixed Prototype Pollution | HandleBars | CWE-471

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,15 +1251,15 @@
       "resolved": "https://registry.npmjs.org/express-hbs/-/express-hbs-1.1.1.tgz",
       "integrity": "sha512-nFBXq8SNb58wospQeRsh3FZL+srv6KMVkCKJnUGB3Gm7pXUf4DzaIQ0zUb+qQRCFeAVQHaF7X4vNfIea00FiGA==",
       "requires": {
-        "handlebars": "4.1.2",
+        "handlebars": "4.3.0",
         "js-beautify": "1.6.8",
         "lodash": "4.17.11",
         "readdirp": "2.1.0"
       },
       "dependencies": {
         "handlebars": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.0.tgz",
           "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
           "requires": {
             "neo-async": "^2.6.0",


### PR DESCRIPTION
Fixed Prototype pollution vulnerability.

Vulnerable module: `handlebars`
Introduced through: ` oneauth@coding-blocks/oneauth#260d43a32f061c74afee7503694aae7bc4c2d872 › express-hbs@1.1.1 › handlebars@4.1.2 `

Your code is vulnerable to Prototype Pollution. Templates may alter an Object's `__proto__` and `__defineGetter__` properties, which may allow an attacker to execute arbitrary code on the server through crafted payloads. I fixed this vulnerability.

Reference:
- https://www.npmjs.com/advisories/1164
- https://github.com/wycats/handlebars.js/commit/7b67a29a8c926b38af265c727ff6551fbb277111