### PR TITLE
fix: email absent in login callback bug

### DIFF
--- a/src/passport/strategies/user/strategy-facebook.js
+++ b/src/passport/strategies/user/strategy-facebook.js
@@ -91,17 +91,21 @@ module.exports = new FacebookStrategy({
                 First ensure there aren't already users with the same email
                 id that comes from facebook
                  */
-                const existingUsers = await models.User.findAll({
-                    include: [{
-                        model: models.UserFacebook,
-                        attributes: ['id'],
-                        required: false
-                    }],
-                    where: {
-                        email: profileJson.email,
-                        '$userfacebook.id$': {$eq: null}
-                    }
-                })
+                let existingUsers = [];
+                if (profileJson.email) {
+                    existingUsers = await models.User.findAll({
+                        include: [{
+                            model: models.UserFacebook,
+                            attributes: ['id'],
+                            required: false
+                        }],
+                        where: {
+                            email: profileJson.email,
+                            '$userfacebook.id$': {$eq: null}
+                        }
+                    })
+                }
+
                 if (existingUsers && existingUsers.length > 0) {
                     let oldIds = existingUsers.map(eu => eu.id).join(',')
                     return cb(null, false, {

--- a/src/passport/strategies/user/strategy-github.js
+++ b/src/passport/strategies/user/strategy-github.js
@@ -73,17 +73,21 @@ module.exports = new GithubStrategy({
                 First ensure there aren't already users with the same email
                 id that comes from Github
                  */
-                const existingUsers = await models.User.findAll({
-                    include: [{
-                        model: models.UserGithub,
-                        attributes: ['id'],
-                        required: false
-                    }],
-                    where: {
-                        email: profileJson.email,
-                        '$usergithub.id$': {$eq: null}
-                    }
-                })
+                let existingUsers = [];
+                if (profileJson.email) {
+                    existingUsers = await models.User.findAll({
+                        include: [{
+                            model: models.UserGithub,
+                            attributes: ['id'],
+                            required: false
+                        }],
+                        where: {
+                            email: profileJson.email,
+                            '$usergithub.id$': {$eq: null}
+                        }
+                    })
+                }
+
                 if (existingUsers && existingUsers.length > 0) {
                     let oldIds = existingUsers.map(eu => eu.id).join(',')
                     return cb(null, false, {

--- a/src/passport/strategies/user/strategy-google.js
+++ b/src/passport/strategies/user/strategy-google.js
@@ -70,18 +70,21 @@ module.exports = new GoogleStrategy({
                     First ensure there aren't already users with the same email
                     id that comes from Google
                      */
+                    let existingUsers = [];
+                    if (profileJson.email) {
+                        existingUsers = await models.User.findAll({
+                            include: [{
+                                model: models.UserGoogle,
+                                attributes: ['id'],
+                                required: false
+                            }],
+                            where: {
+                                email: profileJson.email,
+                                '$usergoogle.id$': {$eq: null}
+                            }
+                        })
+                    }
 
-                    const existingUsers = await models.User.findAll({
-                        include: [{
-                            model: models.UserGoogle,
-                            attributes: ['id'],
-                            required: false
-                        }],
-                        where: {
-                            email: profileJson.email,
-                            '$usergoogle.id$': {$eq: null}
-                        }
-                    })
                     if (existingUsers && existingUsers.length > 0) {
                         let oldIds = existingUsers.map(eu => eu.id).join(',')
                         return cb(null, false, {

--- a/src/passport/strategies/user/strategy-twitter.js
+++ b/src/passport/strategies/user/strategy-twitter.js
@@ -76,17 +76,21 @@ module.exports = new TwitterStrategy({
                  *   First ensure there aren't already users with the same email
                  *   id that comes from Google
                  */
-                const existingUsers = await models.User.findAll({
-                    include: [{
-                        model: models.UserTwitter,
-                        attributes: ['id'],
-                        required: false
-                    }],
-                    where: {
-                        email: profileJson.email,
-                        '$usertwitter.id$': {$eq: null}
-                    }
-                })
+                let existingUsers = []
+                if (profileJson.email) {
+                    existingUsers = await models.User.findAll({
+                        include: [{
+                            model: models.UserTwitter,
+                            attributes: ['id'],
+                            required: false
+                        }],
+                        where: {
+                            email: profileJson.email,
+                            '$usertwitter.id$': {$eq: null}
+                        }
+                    })
+                }
+
                 if (existingUsers && existingUsers.length > 0) {
                     let oldIds = existingUsers.map(eu => eu.id).join(',')
                     return cb(null, false, {


### PR DESCRIPTION
fixes #980, #634 

The callback from social websites (Github, Facebook, Twitter) may or may not contain email id (privacy might be public in case of github, you can make social media account only with mobile number too)

Here, see github shares only public details.
![Screenshot_2020-05-20 Build software better, together](https://user-images.githubusercontent.com/45737735/82445026-c43e3c00-9ac1-11ea-8751-143abf421e9f.png)

[profileJSON.email](https://github.com/coding-blocks/oneauth/blob/9c85ecb530ece704164972aa9826b1bdda13c7b7/src/passport/strategies/user/strategy-github.js#L83) can be null and will then fetch other `Users` with `null` emailId. (those `users` which were created from social media account with no email will have emailId as `null`)  and show that they have same email (`null === null` or `'' === ''` :P) 
